### PR TITLE
Added queuing to prevent multiple notifications being displayed simultaneously.

### DIFF
--- a/AJNotificationView/AJNotificationView.m
+++ b/AJNotificationView/AJNotificationView.m
@@ -38,7 +38,7 @@
 @property (nonatomic, assign) BOOL showDetailDisclosure;
 
 - (void)_drawBackgroundInRect:(CGRect)rect;
-- (void) show;
+- (void) showAfterDelay:(NSTimeInterval)delayInterval;
 
 @end
 


### PR DESCRIPTION
Created a global notification queue so that only one notification is shown at
a time. When a notification is created, it is added to the queue. If it is the
only notification in the queue, then its delay interval is honored. If it is not
the only notification in the queue, it is placed at the end of the queue, and
then displayed without a delay once it reaches the front of the queue.
