### PR TITLE
Bugfix/nil response blocks

### DIFF
--- a/AJNotificationView/AJNotificationView.m
+++ b/AJNotificationView/AJNotificationView.m
@@ -138,7 +138,7 @@ static NSMutableArray *notificationQueue = nil;       // Global notification que
 
 + (AJNotificationView *)showNoticeInView:(UIView *)view type:(AJNotificationType)type title:(NSString *)title linedBackground:(AJLinedBackgroundType)backgroundType hideAfter:(NSTimeInterval)hideInterval offset:(float)offset delay:(NSTimeInterval)delayInterval response:(void (^)(void))response {
     
-    return [self showNoticeInView:view type:type title:title linedBackground:backgroundType hideAfter:hideInterval offset:offset delay:delayInterval detailDisclosure:NO response:nil];
+    return [self showNoticeInView:view type:type title:title linedBackground:backgroundType hideAfter:hideInterval offset:offset delay:delayInterval detailDisclosure:NO response:response];
 }
 
 


### PR DESCRIPTION
Fixes an issue with one of the convenience initializers where the response block was incorrectly being set to nil, causing the response block to never be copied or fired
