### PR TITLE
Some handy methods to hide the current notification and clear the notification queue

### DIFF
--- a/AJNotificationView/AJNotificationView.h
+++ b/AJNotificationView/AJNotificationView.h
@@ -63,4 +63,8 @@ typedef enum {
 //Hide
 - (void)hide;
 
++ (void)hideCurrentNotificationView;
+
++ (void)hideCurrentNotificationViewAndClearQueue;
+
 @end

--- a/AJNotificationView/AJNotificationView.m
+++ b/AJNotificationView/AJNotificationView.m
@@ -271,6 +271,28 @@ static NSMutableArray *notificationQueue = nil;       // Global notification que
                      }];
 }
 
++ (void)hideCurrentNotificationView
+{
+    if([notificationQueue count] > 0)
+    {
+        AJNotificationView *currentNotification = [notificationQueue objectAtIndex:0];
+        [currentNotification hide];
+    }
+}
+
++ (void)hideCurrentNotificationViewAndClearQueue
+{
+    NSUInteger numberOfNotification = [notificationQueue count];
+    
+    if(numberOfNotification > 1)
+    {
+        // remove all notification except the current notification
+        [notificationQueue removeObjectsInRange:NSMakeRange(1, numberOfNotification -1)];
+    }
+    
+    [AJNotificationView hideCurrentNotificationView];
+}
+
 ////////////////////////////////////////////////////////////////////////
 #pragma mark - Touch events
 ////////////////////////////////////////////////////////////////////////

--- a/AJNotificationViewDemo/AJNotificationViewDemo/ViewController.m
+++ b/AJNotificationViewDemo/AJNotificationViewDemo/ViewController.m
@@ -49,16 +49,16 @@
 ////////////////////////////////////////////////////////////////////////
 
 - (IBAction)showNotificaction:(id)sender {
-    panel = [AJNotificationView showNoticeInView:[(AppDelegate *)[[UIApplication sharedApplication] delegate] window]
+    [AJNotificationView showNoticeInView:[(AppDelegate *)[[UIApplication sharedApplication] delegate] window]
                                            title:@"Information notification"
                                        hideAfter:0];
     
 }
 
 - (IBAction)hideNotification:(id)sender {
-    if (panel)
-        [panel hide];
+    [AJNotificationView hideCurrentNotificationView];
 }
+
 - (IBAction)showNotificactionWithoutlines:(id)sender {
     
     //Default demo


### PR DESCRIPTION
Just some methods I found handy to have when using AJNotificationView. Especially when jumping from one ViewController to another and having the ability to programatically hide the notifications and clear the queue. This can potential help with Issue #11
