### PR TITLE
Clear just the notificationQueue without hiding current notificaiton.

### DIFF
--- a/AJNotificationView/AJNotificationView.h
+++ b/AJNotificationView/AJNotificationView.h
@@ -68,4 +68,6 @@ typedef enum {
 
 + (void)hideCurrentNotificationViewAndClearQueue;
 
++ (void)clearQueue;
+
 @end

--- a/AJNotificationView/AJNotificationView.m
+++ b/AJNotificationView/AJNotificationView.m
@@ -307,6 +307,17 @@ static NSMutableArray *notificationQueue = nil;       // Global notification que
     [AJNotificationView hideCurrentNotificationView];
 }
 
++ (void)clearQueue
+{
+    NSUInteger numberOfNotification = [notificationQueue count];
+    
+    if(numberOfNotification > 1)
+    {
+        // remove all notification except the current notification
+        [notificationQueue removeObjectsInRange:NSMakeRange(1, numberOfNotification -1)];
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////
 #pragma mark - Touch events
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I added a method to clear the notificationQueue only instead of just having the one to also hide the notification. I sometimes find this useful and would like to suggest it to be added into your code. At certain points, i found it useful that I wanted to clear the queue but not hide my current notification, especially if it is meant to last several seconds and wouldn't want to end it prematurely.
